### PR TITLE
switch hide_ancestor to hide_pagetypes, remove hiding of RedirectorPage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # silverstripe-hidden-pages
 
-Hides RedirectorPage and VirtualPage automatically and provides an extension to apply to other page classes you wish to hide.
+Hides VirtualPage automatically and provides an extension to apply to other page classes you wish to hide.
 
-Requires Silverstripe 4 or 5+
+Requires Silverstripe 5.2+

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -2,12 +2,10 @@
 Name: fio-hidden-pages
 ---
 
-SilverStripe\CMS\Model\RedirectorPage:
-  hide_ancestor: SilverStripe\CMS\Model\RedirectorPage
-  extensions:
-    fioHiddenPage: Fromholdio\HiddenPages\Extensions\HiddenPageExtension
+SilverStripe\CMS\Model\SiteTree:
+  hide_pagetypes:
+    - SilverStripe\CMS\Model\VirtualPage
 
 SilverStripe\CMS\Model\VirtualPage:
-  hide_ancestor: SilverStripe\CMS\Model\VirtualPage
   extensions:
     fioHiddenPage: Fromholdio\HiddenPages\Extensions\HiddenPageExtension

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "homepage": "https://fromhold.io"
   }],
   "require": {
-    "silverstripe/cms": "~4.0 || ~5.0"
+    "silverstripe/cms": "^5.2"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
- SS 5.2 changes hide_ancestor to hide_pagetypes
- RedirectorPage should not be hidden by default. SuperLinker Redirection takes care of that when replacing the page type

This needs a new major as it breaks in SS 4